### PR TITLE
Feature: Get Invoices by status

### DIFF
--- a/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/services/InvoiceService.kt
+++ b/pleo-antaeus-core/src/main/kotlin/io/pleo/antaeus/core/services/InvoiceService.kt
@@ -16,4 +16,8 @@ class InvoiceService(private val dal: AntaeusDal) {
     fun fetch(id: Int): Invoice {
         return dal.fetchInvoice(id) ?: throw InvoiceNotFoundException(id)
     }
+
+    fun fetchByStatus(status: String): List<Invoice> {
+        return dal.fetchInvoicesByStatus(status)
+    }
 }

--- a/pleo-antaeus-data/src/main/kotlin/io/pleo/antaeus/data/AntaeusDal.kt
+++ b/pleo-antaeus-data/src/main/kotlin/io/pleo/antaeus/data/AntaeusDal.kt
@@ -38,6 +38,14 @@ class AntaeusDal(private val db: Database) {
         }
     }
 
+    fun fetchInvoicesByStatus(status: String): List<Invoice> {
+        return transaction(db) {
+            InvoiceTable
+                .selectAll( { InvoiceTable.status.eq(status) } )
+                .map { it.toInvoice() }
+        }
+    }
+
     fun createInvoice(amount: Money, customer: Customer, status: InvoiceStatus = InvoiceStatus.PENDING): Invoice? {
         val id = transaction(db) {
             // Insert the invoice and returns its new id.

--- a/pleo-antaeus-data/src/main/kotlin/io/pleo/antaeus/data/AntaeusDal.kt
+++ b/pleo-antaeus-data/src/main/kotlin/io/pleo/antaeus/data/AntaeusDal.kt
@@ -41,7 +41,7 @@ class AntaeusDal(private val db: Database) {
     fun fetchInvoicesByStatus(status: String): List<Invoice> {
         return transaction(db) {
             InvoiceTable
-                .selectAll( { InvoiceTable.status.eq(status) } )
+                .select { InvoiceTable.status like status }
                 .map { it.toInvoice() }
         }
     }

--- a/pleo-antaeus-rest/src/main/kotlin/io/pleo/antaeus/rest/AntaeusRest.kt
+++ b/pleo-antaeus-rest/src/main/kotlin/io/pleo/antaeus/rest/AntaeusRest.kt
@@ -61,6 +61,11 @@ class AntaeusRest (
                        get(":id") {
                           it.json(invoiceService.fetch(it.pathParam("id").toInt()))
                        }
+
+                       // URL: /rest/v1/invoices/status/{:status}
+                       get("/status/:status") {
+                          it.json(invoiceService.fetchByStatus(it.pathParam("status").toString()))
+                       }
                    }
 
                    path("customers") {


### PR DESCRIPTION
This feature enables us to query a list of invoices by the statuses `pending`, `paid` and `unpaid`.

To do:
- [x] Create /status/:status rest endpoint.
- [x] Add a `fetchByStatus` endpoiunt in the `InvoiceService`
- [x] Add a `fetchInvoiceByStatus` function in the `AntaeusDal`

References: [Card](https://github.com/bmwachajr/antaeus/projects/1#card-24245028)